### PR TITLE
Fix local network access on Android 17

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />

--- a/app/src/main/java/com/imnotndesh/truehub/MainActivity.kt
+++ b/app/src/main/java/com/imnotndesh/truehub/MainActivity.kt
@@ -3,6 +3,7 @@ package com.imnotndesh.truehub
 import android.Manifest
 import android.app.Application
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -120,9 +121,25 @@ fun MainActivityContent(
     val notifPermission = rememberPermissionState(
         Manifest.permission.POST_NOTIFICATIONS
     )
+    val localNetworkPermission = if (
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN
+    ) {
+        rememberPermissionState(
+            permission = Manifest.permission.ACCESS_LOCAL_NETWORK,
+            onPermissionResult = {
+                viewModel.initializeApp(context)
+            }
+        )
+    } else {
+        null
+    }
 
     LaunchedEffect(Unit) {
-        viewModel.initializeApp(context)
+        if (localNetworkPermission != null && !localNetworkPermission.status.isGranted) {
+            localNetworkPermission.launchPermissionRequest()
+        } else {
+            viewModel.initializeApp(context)
+        }
     }
     LaunchedEffect(manager) {
         manager?.let {


### PR DESCRIPTION
## What changed

Android 17 requires apps targeting SDK 37 to request local network access before connecting to devices on the LAN.

This adds the `ACCESS_LOCAL_NETWORK` permission and requests it at startup on Android 17+. Older Android versions keep the existing behavior.

## Why

Without the permission, connections to a local TrueNAS server can just time out even though the server is reachable from the browser.

This may also be the cause of #96 if that GrapheneOS device is up to date and running Android 17, since the reported symptoms are very similar.

## Tested

Built and installed the GitHub debug APK on a physical Android 17 device and confirmed I can connect and log in to a local TrueNAS instance after granting the Local Network permission.

`testGithubDebugUnitTest` and `assembleGithubDebug` pass.

`lintGithubDebug` still fails on 3 existing `UnusedMaterial3ScaffoldPaddingParameter` errors in unrelated files. This change does not add any new lint warnings.
